### PR TITLE
Bugfix: Fix CUDA 9 and 10 CI fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,15 +69,15 @@ before_install:
   - sudo apt-get install -y cuda-core-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} cuda-cufft-dev-${CUDA_APT}
   - sudo apt-get clean
   - CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
-  - LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
   - PATH=${CUDA_HOME}/bin:${PATH}
   - sudo apt-get install gfortran
 
 script:
   - . compiler_setup/gnu.sh
-  - gcc --version
-  - gfortran --version
-  - nvcc --version
+  - . compiler_setup/cuda.sh
+  - echo "\nGCC Info:\n--------" && which gcc && gcc --version
+  - echo "GFortran Info\n-------------" && which gfortran && gfortran --version
+  - echo "\nNVCC Version\n------------" && which nvcc && nvcc --version
   - make
   - cd original
   - ./nemolite2d.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,9 @@ before_install:
   - sudo dpkg -i ${INSTALLER}
   - wget https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/7fa2af80.pub
   - sudo apt-key add 7fa2af80.pub
-  - sudo apt update -qq
-  - sudo apt install -y cuda-core-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} cuda-cufft-dev-${CUDA_APT}
-  - sudo apt clean
+  - sudo apt-get update -qq
+  - sudo apt-get install -y cuda-core-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} cuda-cufft-dev-${CUDA_APT}
+  - sudo apt-get clean
   - CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
   - LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
   - PATH=${CUDA_HOME}/bin:${PATH}

--- a/compiler_setup/cuda.sh
+++ b/compiler_setup/cuda.sh
@@ -12,7 +12,16 @@ command -v nvcc >/dev/null 2>&1 || {
 
 NVCC_PATH=$(which nvcc)
 CUDA_BIN=$(dirname "$NVCC_PATH")
-CUDA_DIR=$(dirname "$CUDA_BIN")
+CUDA_HOME=$(dirname "$CUDA_BIN")
 
-export C_INCLUDE_PATH="$CUDA_DIR/include/:$C_INCLUDE_PATH"
-export LD_LIBRARY_PATH="$CUDA_DIR/lib64/:$LD_LIBRARY_PATH"
+export CUDA_INC="$CUDA_HOME/include"
+export CUDA_LIB="$CUDA_HOME/lib64"
+
+export C_INCLUDE_PATH="$CUDA_INC:$C_INCLUDE_PATH"
+export LD_LIBRARY_PATH="$CUDA_LIB:$LD_LIBRARY_PATH"
+
+# Always using Volta GV100 (either Quadro or Tesla) that supports compute
+# capacity 7.0.
+export CUDA_ARCH=sm_70
+
+echo "CUDA home directory: $CUDA_HOME"

--- a/compiler_setup/cuda.sh
+++ b/compiler_setup/cuda.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+command -v module >/dev/null 2>&1 && {
+    module load gcc
+    module load cuda
+}
+
+command -v nvcc >/dev/null 2>&1 || {
+    echo "Unable to find 'nvcc' CUDA compiler."
+    return 1
+}
+
+NVCC_PATH=$(which nvcc)
+CUDA_BIN=$(dirname "$NVCC_PATH")
+CUDA_DIR=$(dirname "$CUDA_BIN")
+
+export C_INCLUDE_PATH="$CUDA_DIR/include/:$C_INCLUDE_PATH"
+export LD_LIBRARY_PATH="$CUDA_DIR/lib64/:$LD_LIBRARY_PATH"

--- a/original/Makefile
+++ b/original/Makefile
@@ -13,7 +13,7 @@ TIMER_LIB = ${TIMER_DIR}/dl_timer_lib.a
 INF_DIR = ${SHARED_DIR}/dl_esm_inf/finite_difference
 INF_INC = ${INF_DIR}/src
 INF_LIB = ${INF_DIR}/src/dl_esm_inf_fd.a
-NVCC_FLAGS = -O3 -std=c++14 -use_fast_math -arch=$(CUDA_ARCH) --ptxas-options=-v
+NVCC_FLAGS = -O3 -std=c++14 -use_fast_math -arch=$(CUDA_ARCH) --ptxas-options=-v -lineinfo
 CUDA_OBJS = cuda_nemolite2d.o
 
 EXECS = nemolite2d

--- a/original/Makefile
+++ b/original/Makefile
@@ -13,7 +13,7 @@ TIMER_LIB = ${TIMER_DIR}/dl_timer_lib.a
 INF_DIR = ${SHARED_DIR}/dl_esm_inf/finite_difference
 INF_INC = ${INF_DIR}/src
 INF_LIB = ${INF_DIR}/src/dl_esm_inf_fd.a
-NVCC_LIB = -lcudart
+NVCC_FLAGS = -O3 -std=c++14 -use_fast_math -arch=$(CUDA_ARCH) --ptxas-options=-v
 CUDA_OBJS = cuda_nemolite2d.o
 
 EXECS = nemolite2d
@@ -44,7 +44,7 @@ cuda_nemolite2d.o: $(COMMON_MODULES)
 # Generic rules
 
 %.exe: $(MODULE_LIST)
-	$(F90) $(OMPFLAGS) -o $@ $(MODULE_LIST) $(TIMER_LIB) $(LDFLAGS) $(NVCC_LIB)
+	$(F90) $(OMPFLAGS) -o $@ $(MODULE_LIST) $(TIMER_LIB) $(LDFLAGS) -L$(CUDA_LIB) -lcudart
 
 %.o: %.f90
 	$(F90) $(F90FLAGS) -I${INF_INC} -I${TIMER_INC} -c $<
@@ -53,7 +53,7 @@ cuda_nemolite2d.o: $(COMMON_MODULES)
 	$(F90) $(F90FLAGS) -I${INF_INC} -I${TIMER_INC} -c $<
 
 %.o: %.cu
-	$(NVCC) $(NVCC_FLAGS) -c $<
+	$(NVCC) $(NVCC_FLAGS) -c -I$(CUDA_INC) $<
 
 # Cleaning up
 

--- a/original/Makefile
+++ b/original/Makefile
@@ -13,8 +13,7 @@ TIMER_LIB = ${TIMER_DIR}/dl_timer_lib.a
 INF_DIR = ${SHARED_DIR}/dl_esm_inf/finite_difference
 INF_INC = ${INF_DIR}/src
 INF_LIB = ${INF_DIR}/src/dl_esm_inf_fd.a
-NVCC_INC = /usr/local/cuda-8.0/include/ 
-NVCC_LIB = -L/usr/local/cuda-8.0/lib64/ -lcudart
+NVCC_LIB = -lcudart
 CUDA_OBJS = cuda_nemolite2d.o
 
 EXECS = nemolite2d
@@ -54,7 +53,7 @@ cuda_nemolite2d.o: $(COMMON_MODULES)
 	$(F90) $(F90FLAGS) -I${INF_INC} -I${TIMER_INC} -c $<
 
 %.o: %.cu
-	$(NVCC) $(NVCC_FLAGS) -I$(NVCC_INC) -c $<
+	$(NVCC) $(NVCC_FLAGS) -c $<
 
 # Cleaning up
 


### PR DESCRIPTION
Compilation is able to work with multiple CUDA versions (compiled on TravisCI on 8, 9 and 10).