### PR TITLE
Feature: Add NVTX markers to OpenACC implementation.

### DIFF
--- a/compiler_setup/pgi_acc.sh
+++ b/compiler_setup/pgi_acc.sh
@@ -3,8 +3,8 @@
 # Fortran compiler
 F90=pgf90
 # C compiler
-CC=pgc++
-CFLAGS=" -I /opt/pgi/linux86-64-llvm/2019/cuda/10.0/include/ "
+CXX=pgc++
+CXXFLAGS+=" -I /opt/pgi/linux86-64-llvm/2019/cuda/10.0/include/ "
 # Fortran compiler flags
 F90FLAGS="-O3 -Minfo=all"
 #F90FLAGS"+=" -fcheck=all -fbacktrace -ffpe-trap=invalid -g -O0"
@@ -34,6 +34,6 @@ export F90
 export F90FLAGS
 export LDFLAGS
 export AR
-export CC
-export CFLAGS
+export CXX
+export CXXFLAGS
 

--- a/compiler_setup/pgi_acc.sh
+++ b/compiler_setup/pgi_acc.sh
@@ -3,8 +3,8 @@
 # Fortran compiler
 F90=pgf90
 # C compiler
-CC=pgcc
-CFLAGS="-g"
+CC=pgc++
+CFLAGS=" -I /opt/pgi/linux86-64-llvm/2019/cuda/10.0/include/ "
 # Fortran compiler flags
 F90FLAGS="-O3 -Minfo=all"
 #F90FLAGS"+=" -fcheck=all -fbacktrace -ffpe-trap=invalid -g -O0"
@@ -17,12 +17,12 @@ F90FLAGS="-O3 -Minfo=all"
 # shoul be a multiple of 8.
 # -Mcuda is required to build CUDA Fortran
 # For Quadro K600
-F90FLAGS+=" -acc -ta=tesla:cc70,nordc -Mcuda=cc70,nordc"
+F90FLAGS+=" -acc -ta=tesla:cc70,nordc -Mcuda=cc70,nordc "
 # For Tesla K20c
 #F90FLAGS+=" -acc -ta=tesla,cc35,maxregcount:80,nordc -Mcuda=cc35,maxregcount:80,nordc"
 # Linker flags
 # For Quadro K600
-LDFLAGS+=" -acc -ta=tesla,cc70 -Mcuda=cc70,nordc"
+LDFLAGS+=" -acc -ta=tesla,cc70 -Mcuda=cc70,nordc -lnvToolsExt "
 # For Tesla K20c
 #LDFLAGS="-acc -ta=nvidia,cc35 -Mcuda=cc35,nordc"
 # Flags to use when compiling with OpenMP support
@@ -34,4 +34,6 @@ export F90
 export F90FLAGS
 export LDFLAGS
 export AR
+export CC
+export CFLAGS
 

--- a/openacc/Makefile
+++ b/openacc/Makefile
@@ -26,7 +26,7 @@ all: $(EXECS)
 
 # Normal targets
 nemolite2d: inf_lib timer_lib
-	${MAKE} MODULE_LIST="nemolite2d.o ${COMMON_MODULES}" nemolite2d.exe
+	${MAKE} MODULE_LIST="nemolite2d.o nvtx.o nvtx_wrapper.o${COMMON_MODULES}" nemolite2d.exe
 
 timer_lib:
 	${MAKE} -C ${TIMER_DIR} sm_lib
@@ -34,7 +34,7 @@ timer_lib:
 inf_lib:
 	${MAKE} -C ${INF_DIR}
 
-nemolite2d.o: $(COMMON_MODULES)
+nemolite2d.o: $(COMMON_MODULES) nvtx.o nvtx_wrapper.o 
 
 # Generic rules
 
@@ -46,6 +46,9 @@ nemolite2d.o: $(COMMON_MODULES)
 
 %.o: %.F90
 	$(F90) $(F90FLAGS) -I${INF_INC} -I${TIMER_INC} -c $<
+
+%.o: %.cpp
+	$(CC) $(CCFLAGS) -c $<
 
 # Cleaning up
 

--- a/openacc/Makefile
+++ b/openacc/Makefile
@@ -26,7 +26,7 @@ all: $(EXECS)
 
 # Normal targets
 nemolite2d: inf_lib timer_lib
-	${MAKE} MODULE_LIST="nemolite2d.o nvtx.o nvtx_wrapper.o${COMMON_MODULES}" nemolite2d.exe
+	${MAKE} MODULE_LIST="nvtx.o nvtx_wrapper.o nemolite2d.o ${COMMON_MODULES}" nemolite2d.exe
 
 timer_lib:
 	${MAKE} -C ${TIMER_DIR} sm_lib
@@ -34,7 +34,7 @@ timer_lib:
 inf_lib:
 	${MAKE} -C ${INF_DIR}
 
-nemolite2d.o: $(COMMON_MODULES) nvtx.o nvtx_wrapper.o 
+nemolite2d.o: nvtx.o nvtx_wrapper.o $(COMMON_MODULES)  
 
 # Generic rules
 
@@ -48,7 +48,7 @@ nemolite2d.o: $(COMMON_MODULES) nvtx.o nvtx_wrapper.o
 	$(F90) $(F90FLAGS) -I${INF_INC} -I${TIMER_INC} -c $<
 
 %.o: %.cpp
-	$(CC) $(CCFLAGS) -c $<
+	$(CXX) $(CXXFLAGS) -c $<
 
 # Cleaning up
 

--- a/openacc/Makefile
+++ b/openacc/Makefile
@@ -19,6 +19,7 @@ EXECS = nemolite2d
 # API lib is an archive that must come at the end of the list of objects
 # passed to the linker
 COMMON_MODULES = ${INF_LIB}
+NVTX_OBJECTS = nvtx.o nvtx_wrapper.o
 
 .PHONY: all nemolite2d timer_lib inf_lib
 
@@ -26,7 +27,7 @@ all: $(EXECS)
 
 # Normal targets
 nemolite2d: inf_lib timer_lib
-	${MAKE} MODULE_LIST="nvtx.o nvtx_wrapper.o nemolite2d.o ${COMMON_MODULES}" nemolite2d.exe
+	${MAKE} MODULE_LIST="${NVTX_OBJECTS} nemolite2d.o ${COMMON_MODULES}" nemolite2d.exe
 
 timer_lib:
 	${MAKE} -C ${TIMER_DIR} sm_lib
@@ -34,7 +35,7 @@ timer_lib:
 inf_lib:
 	${MAKE} -C ${INF_DIR}
 
-nemolite2d.o: nvtx.o nvtx_wrapper.o $(COMMON_MODULES)  
+nemolite2d.o: ${NVTX_OBJECTS} $(COMMON_MODULES)  
 
 # Generic rules
 

--- a/openacc/nemolite2d.f90
+++ b/openacc/nemolite2d.f90
@@ -6,6 +6,7 @@ PROGRAM nemolite2d
     use dl_timer
     use field_mod, only: field_checksum
     use gocean_mod, only: model_write_log
+    use nvtx, only: nvtxrangepushaargb, nvtxrangepop
     IMPLICIT NONE
 
     INTEGER, PARAMETER :: sp = c_float
@@ -333,7 +334,7 @@ CONTAINS
 !+++++++++++++++++++++++++++++++++++
 
     SUBROUTINE initialisation
-
+        call nvtxrangepushaargb("range_name"//char(0),int(z'ff00ffec',4))!ff00ffec==colour
         call timer_init()
 
         ! define (or read in) initil ssh and velocity fields
@@ -378,7 +379,7 @@ CONTAINS
 ! This call updates 'a' quantities which are not used before the code
 ! in step again updates them. Therefore I think it does nothing. ARP.
 !            CALL bc(0._wp)
-
+        call nvtxrangepop
     END SUBROUTINE initialisation
 
 !+++++++++++++++++++++++++++++++++++

--- a/openacc/nemolite2d.f90
+++ b/openacc/nemolite2d.f90
@@ -385,8 +385,8 @@ CONTAINS
 !+++++++++++++++++++++++++++++++++++
 
     SUBROUTINE step
-        call nvtxrangepushaargb("step"//char(0),int(z'aaaaaaec',4))!ff00ffec==colour
         REAL(wp) :: rtime
+        call nvtxrangepushaargb("step"//char(0),int(z'aaaaaaec',4))!ff00ffec==colour
 
 
         rtime = REAL(istp, wp)*rdt

--- a/openacc/nemolite2d.f90
+++ b/openacc/nemolite2d.f90
@@ -334,7 +334,7 @@ CONTAINS
 !+++++++++++++++++++++++++++++++++++
 
     SUBROUTINE initialisation
-        call nvtxrangepushaargb("range_name"//char(0),int(z'ff00ffec',4))!ff00ffec==colour
+        call nvtxrangepushaargb("initialisation"//char(0),int(z'ff00ffec',4))!ff00ffec==colour
         call timer_init()
 
         ! define (or read in) initil ssh and velocity fields
@@ -385,23 +385,36 @@ CONTAINS
 !+++++++++++++++++++++++++++++++++++
 
     SUBROUTINE step
+        call nvtxrangepushaargb("step"//char(0),int(z'aaaaaaec',4))!ff00ffec==colour
         REAL(wp) :: rtime
+
 
         rtime = REAL(istp, wp)*rdt
 
         ! These three kernels can happen async independently of each other.
+        call nvtxrangepushaargb("step"//char(0),int(z'ff0000ec',4))!
         CALL continuity
+        call nvtxrangepop
+        call nvtxrangepushaargb("step"//char(0),int(z'00ff00ec',4))!
         CALL momentum
+        call nvtxrangepop
+        call nvtxrangepushaargb("step"//char(0),int(z'0000ffec',4))!
         CALL bc(rtime)  ! open and solid boundary condition
+        call nvtxrangepop
 
         ! 'Next' kernel updates the five output arrays, so they need updating on host & device.
+        call nvtxrangepushaargb("step"//char(0),int(z'ffff00ec',4))!
         CALL next
+        call nvtxrangepop
+
 
         IF (MOD(istp, irecord) == 0) THEN
             !$acc update self(un, vn, sshn, sshn_u, sshn_v)
+            call nvtxrangepushaargb("step"//char(0),int(z'00ffffec',4))!
             CALL output
+            call nvtxrangepop
         END IF
-
+        call nvtxrangepop
     END SUBROUTINE step
 
 !+++++++++++++++++++++++++++++++++++

--- a/openacc/nvtx.f90
+++ b/openacc/nvtx.f90
@@ -1,0 +1,46 @@
+! Fortran bindings for a small subset of the NVIDIA Tools Extensions library
+module nvtx
+ use iso_c_binding
+ public :: nvtxrangepusha, nvtxrangepop
+ public :: nvtxrangepushaargb
+ interface
+   ! Annotate the timeline with a message
+   ! Parameters:
+   ! * string : the message in a string format
+   subroutine nvtxrangepusha(string) bind(C, name="nvtxRangePushA")
+     use iso_c_binding , only : c_char
+     character(kind=c_char) :: string(*)
+   end subroutine nvtxrangepusha
+
+   ! Annotate the timeline with both a message and an ARGB color
+   ! Parameters:
+   ! * string : the message in a string format
+   ! * argb  : the color in argb format (example: Z'FF880000'
+   subroutine nvtxrangepushaargb(string,argb) bind(C, name="_nvtxRangePushAARGB")
+     use iso_c_binding , only : c_char, c_int
+     character(kind=c_char) :: string(*)
+     integer(kind=c_int), value :: argb
+   end subroutine nvtxrangepushaargb
+
+   ! Pop the last range off the stack
+   subroutine nvtxrangepop() bind(C, name="nvtxRangePop")
+   end subroutine
+
+   ! Place a mark on the timeline with a message
+   ! Parameters:
+   ! * string : the message in a string format
+   ! NOT YET EXPOSED
+   subroutine nvtxMarkA(string) bind(C, name="nvtxMarkA")
+     use iso_c_binding , only : c_char
+     character(kind=c_char) :: string(*)
+   end subroutine
+
+   ! Name an OS thread
+   ! NOT YET EXPOSED
+   subroutine nvtxNameOsThread(tid, string) bind(C, name="nvtxNameOsThread")
+     use iso_c_binding , only : c_int, c_char
+     integer(kind=c_int) :: tid
+     character(kind=c_char) :: string(*)
+   end subroutine
+ end interface
+end module nvtx

--- a/openacc/nvtx_wrapper.cpp
+++ b/openacc/nvtx_wrapper.cpp
@@ -1,4 +1,5 @@
 #include <nvToolsExt.h>
+#pragma once
 /*
  * Utility routine for marking a range with both
  * a message and a color from a single function call.

--- a/openacc/nvtx_wrapper.cpp
+++ b/openacc/nvtx_wrapper.cpp
@@ -1,0 +1,17 @@
+#include <nvToolsExt.h>
+/*
+ * Utility routine for marking a range with both
+ * a message and a color from a single function call.
+ */
+extern "C"
+void _nvtxRangePushAARGB(char *message, int argb)
+{
+ nvtxEventAttributes_t eventAttrib = {0};
+ eventAttrib.version = NVTX_VERSION;
+ eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+ eventAttrib.colorType = NVTX_COLOR_ARGB;
+ eventAttrib.color = argb; //0xff0000ff;
+ eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+ eventAttrib.message.ascii = message;
+ nvtxRangePushEx(&eventAttrib);
+}


### PR DESCRIPTION
This is not polished enough to include generically (i've not bothered to find the nvtx include path / lib directory in a generic fashion). 

It indicates that the initial wait time is for the first call to OUTPUT, so not within the scope of the GPU hackathon to improve. 

This is for reference really, rather than to actually be merged. 