### PR TITLE
Swich to cuda occupancy api calls for blockdims

### DIFF
--- a/cuda/cuda_nemolite2d.cu
+++ b/cuda/cuda_nemolite2d.cu
@@ -362,7 +362,7 @@ cuda_initialise_grid_()
 
   dim3 threads_per_block;
   dim3 num_blocks;
-  get_kernel_dims(jpi + 2, jpj + 2, threads_per_block, num_blocks);
+  get_kernel_dims(jpi + 2, jpj + 2, k_initialise_grid, threads_per_block, num_blocks);
 
   printf("Kernel dimensions: ((%d, %d), (%d, %d).\n",
          threads_per_block.x,
@@ -453,7 +453,7 @@ cuda_continuity_()
 
   dim3 threads_per_block;
   dim3 num_blocks;
-  get_kernel_dims(jpi + 1, jpj + 1, threads_per_block, num_blocks);
+  get_kernel_dims(jpi + 1, jpj + 1, k_continuity, threads_per_block, num_blocks);
 
   k_continuity<<<num_blocks, threads_per_block>>>(*simulation_vars.sshn,
                                                   *simulation_vars.sshn_u,
@@ -489,7 +489,7 @@ cuda_boundary_conditions_(wp_t rtime)
 
   dim3 threads_per_block;
   dim3 num_blocks;
-  get_kernel_dims(jpi + 1, jpj + 1, threads_per_block, num_blocks);
+  get_kernel_dims(jpi + 1, jpj + 1, k_boundary_conditions, threads_per_block, num_blocks);
 
   k_boundary_conditions<<<num_blocks, threads_per_block>>>(
     rtime,
@@ -538,7 +538,7 @@ cuda_next_()
 
   dim3 threads_per_block;
   dim3 num_blocks;
-  get_kernel_dims(jpi + 1, jpj + 1, threads_per_block, num_blocks);
+  get_kernel_dims(jpi + 1, jpj + 1, k_next, threads_per_block, num_blocks);
 
   k_next<<<num_blocks, threads_per_block>>>(*simulation_vars.sshn,
                                             *simulation_vars.sshn_u,


### PR DESCRIPTION
Use the occupancy calculator to select a number of threads per block to maximise device utilisation. 

This takes the kernel as a template parameter which is needed by the occupancy calculator.

