### PR TITLE
Add script for profiling openacc implementation using the newer profi…

### DIFF
--- a/tools/profile-openacc-nsys.sh
+++ b/tools/profile-openacc-nsys.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Simple bash script for lazy profiling. 
+cd "$(dirname "$0")"
+
+# Configuration params
+DEFAULT_SCALE=512
+TARGET_DIR="../openacc"
+WORKING_DIR="."
+
+# Constants
+NAMELIST="namelist"
+EXECUTABLE="nemolite2d.exe"
+
+# Get the date time this was initiated.
+DATETIME=$(date '+%Y%m%d-%H%M%S')
+
+# help message fn.
+usage(){
+    echo "usage: $0 [-h] [-s|--scale SCALE] [-m|--metrics] [--dry-run]]"
+}
+
+# function to run th eprofile.
+profile(){
+    SCALE=$1
+    METRICS=$2
+    DRYRUN=$3
+
+    TARGET_NAMELIST="namelist.$SCALE.profile"
+    TIMELINE_FILE="$SCALE-$DATETIME-nsight-timeline"
+    METRICS_FILE="$SCALE-$DATETIME-nsight-cu-metrics"
+    # Log a messsage.
+    echo "Profiling $SCALE using $TARGET_DIR/$EXECUTABLE"
+
+    # Check the namelist file exists.
+    if [ ! -f "$TARGET_DIR/$TARGET_NAMELIST" ]; then
+        echo "Error: $TARGET_DIR/$TARGET_NAMELIST does not exist"
+        return
+    fi
+
+    # Update the namelist file (symlink)
+    rm -f "$WORKING_DIR/$NAMELIST"
+    ln -s "$TARGET_DIR/$TARGET_NAMELIST" "$WORKING_DIR/$NAMELIST"
+
+    # Capture a timeline
+    timeline_command="nsys profile -f true -o $TARGET_DIR/$TIMELINE_FILE $TARGET_DIR/$EXECUTABLE"
+    if [ "$DRYRUN" = "0" ]; then
+        $timeline_command
+    else
+        echo "$timeline_command"
+    fi 
+
+    # optionally capture full details
+    metrics_command="nv-nsight-cu-cli -f -o $TARGET_DIR/$METRICS_FILE $TARGET_DIR/$EXECUTABLE"
+    if [ "$METRICS" = "1" ]; then
+        if [ "$DRYRUN" = "0" ]; then
+            $metrics_command
+        else
+            echo "$metrics_command"
+        fi 
+    fi
+
+    # Revert the namelist file.
+    rm "$WORKING_DIR/$NAMELIST"
+}
+
+# Check some usage and run the sript. 
+scale=$DEFAULT_SCALE
+metrics=0
+dryrun=0
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -s | --scale )          shift
+                                scale=$1
+                                ;;
+        -m | --metrics )        metrics=1
+                                ;;
+             --dry-run )        dryrun=1
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
+# Run the profile fn
+profile $scale $metrics $dryrun


### PR DESCRIPTION
…lers

uses nsys (nsight systems) for timeline profiling and nsight compute (nv-nsight-cu-cli) for device profiling.

Requires CC61 or greater GPU, and best with CUDA 10.1 or newer (10.0 is OK)